### PR TITLE
lazy evaluate on logic expression

### DIFF
--- a/test/syntax_test.dart
+++ b/test/syntax_test.dart
@@ -258,6 +258,16 @@ void main() {
       expect(tmpl.render(), equals('{{ FOO }} and {% BAR %}'));
     });
 
+    test('operator and', () {
+      final tmpl = env.fromString('<{% if page.next and page.next.path %}ok{% endif %}>');
+      expect(tmpl.render({'page': {}}), equals('<>'));
+    });
+
+    test('operator or', () {
+      final tmpl = env.fromString('<{% if page.next or empty.test %}ok{% endif %}>');
+      expect(tmpl.render({'page': {'next': '5'}}), equals('<ok>'));
+    });
+
     test('const', () {
       var tmpl = env.fromString('{{ true }}');
       expect(tmpl.render(), equals('true'));


### PR DESCRIPTION
In case `{% if page.next and page.next.path %}`, currently jinja would throw `NoSuchMethodError: The method '[]("path")' was called on null`, actually it did not need to evaluate right expression of `Binary`.

maybe change `calc` directly is more simple, but that may break your `static Object? calc()` style, so I extends a `_LogicBinary` class so as to keep it.