### PR TITLE
Added passContext for Functions

### DIFF
--- a/lib/src/context.dart
+++ b/lib/src/context.dart
@@ -20,6 +20,10 @@ class Context {
       [List<Object?>? positional, Map<Symbol, Object?>? named]) {
     var function = object.call as Function;
     positional ??= <Object?>[];
+    var  pass = Environment.passArguments[function];
+    if (pass == PassArgument.context) {
+      positional.insert(0, this);
+    }
     return Function.apply(function, positional, named);
   }
 

--- a/lib/src/context.dart
+++ b/lib/src/context.dart
@@ -20,10 +20,15 @@ class Context {
       [List<Object?>? positional, Map<Symbol, Object?>? named]) {
     var function = object.call as Function;
     positional ??= <Object?>[];
+
     var  pass = Environment.passArguments[function];
+
     if (pass == PassArgument.context) {
       positional.insert(0, this);
+    } else if (pass == PassArgument.environment) {
+      positional.insert(0, environment);
     }
+
     return Function.apply(function, positional, named);
   }
 

--- a/test/functions_test.dart
+++ b/test/functions_test.dart
@@ -55,5 +55,14 @@ void main() {
       var out = env.fromString("{{ test_func('positional argument value') }}");
       expect(out.render(data), '[positional argument value] {default} env.commentStart = {#');
     });
+    test('named argument', () {
+      var data = {'bar': 42};
+      var env = Environment(
+        getAttribute: getAttribute,
+        globals: {'test_func': passEnvironment(testFuncWithEnvironment)},
+      );
+      var out = env.fromString("{{ test_func('positional argument value', namedArgument='named argument') }}");
+      expect(out.render(data), '[positional argument value] {named argument} env.commentStart = {#');
+    });
   });
 }

--- a/test/functions_test.dart
+++ b/test/functions_test.dart
@@ -15,21 +15,29 @@ Object? testFuncWithoutContext({String namedArg1 = 'default'}) {
 void main() {
   group('No Context', () {
     test('Named Argument', () {
-      var data = {'ignore': 'me'};
       var env = Environment(globals: {'test_func': testFuncWithoutContext});
       var out = env.fromString("{{ test_func(namedArg1='testing') }}");
-      expect(out.render(data), 'testing');
+      expect(out.render(), 'testing');
     });
   });
   group('With Context', () {
-    var data = {'bar': 42};
     test('Named Argument', () {
+      var data = {'bar': 42};
       var env = Environment(
         getAttribute: getAttribute,
         globals: {'test_func': passContext(testFuncWithContext)},
       );
       var out = env.fromString("{{ test_func(namedArg1='testing') }}");
       expect(out.render(data), 'testing42');
+    });
+    test('Named Argument Missing', () {
+      var data = {'bar': 42};
+      var env = Environment(
+        getAttribute: getAttribute,
+        globals: {'test_func': passContext(testFuncWithContext)},
+      );
+      var out = env.fromString("{{ test_func() }}");
+      expect(out.render(data), 'default42');
     });
   });
 }

--- a/test/functions_test.dart
+++ b/test/functions_test.dart
@@ -1,0 +1,35 @@
+import 'package:jinja/jinja.dart';
+import 'package:jinja/reflection.dart';
+import 'package:jinja/src/context.dart';
+import 'package:test/test.dart';
+
+Object? testFuncWithContext(Context context, {String namedArg1 = 'default'}) {
+  var bar = context.get('bar');
+  return namedArg1+bar.toString();
+}
+
+Object? testFuncWithoutContext({String namedArg1 = 'default'}) {
+  return namedArg1;
+}
+
+void main() {
+  group('No Context', () {
+    test('Named Argument', () {
+      var data = {'ignore': 'me'};
+      var env = Environment(globals: {'test_func': testFuncWithoutContext});
+      var out = env.fromString("{{ test_func(namedArg1='testing') }}");
+      expect(out.render(data), 'testing');
+    });
+  });
+  group('With Context', () {
+    var data = {'bar': 42};
+    test('Named Argument', () {
+      var env = Environment(
+        getAttribute: getAttribute,
+        globals: {'test_func': passContext(testFuncWithContext)},
+      );
+      var out = env.fromString("{{ test_func(namedArg1='testing') }}");
+      expect(out.render(data), 'testing42');
+    });
+  });
+}

--- a/test/functions_test.dart
+++ b/test/functions_test.dart
@@ -3,34 +3,38 @@ import 'package:jinja/reflection.dart';
 import 'package:jinja/src/context.dart';
 import 'package:test/test.dart';
 
-Object? testFuncWithContext(Context context, {String namedArg1 = 'default'}) {
+Object? testFuncWithContext(Context context, {String namedArgument = 'default'}) {
   var bar = context.get('bar');
-  return namedArg1+bar.toString();
+  return namedArgument+bar.toString();
 }
 
-Object? testFuncWithoutContext({String namedArg1 = 'default'}) {
-  return namedArg1;
+Object? testFuncWithoutContext({String namedArgument = 'default'}) {
+  return namedArgument;
+}
+
+Object? testFuncWithEnvironment(Environment env, String positionalArgument, {String namedArgument = 'default'}) {
+  return "[$positionalArgument] {$namedArgument} env.commentStart = ${env.commentStart}";
 }
 
 void main() {
   group('No Context', () {
-    test('Named Argument', () {
+    test('named argument', () {
       var env = Environment(globals: {'test_func': testFuncWithoutContext});
-      var out = env.fromString("{{ test_func(namedArg1='testing') }}");
+      var out = env.fromString("{{ test_func(namedArgument='testing') }}");
       expect(out.render(), 'testing');
     });
   });
   group('With Context', () {
-    test('Named Argument', () {
+    test('named argument', () {
       var data = {'bar': 42};
       var env = Environment(
         getAttribute: getAttribute,
         globals: {'test_func': passContext(testFuncWithContext)},
       );
-      var out = env.fromString("{{ test_func(namedArg1='testing') }}");
+      var out = env.fromString("{{ test_func(namedArgument='testing') }}");
       expect(out.render(data), 'testing42');
     });
-    test('Named Argument Missing', () {
+    test('named argument missing', () {
       var data = {'bar': 42};
       var env = Environment(
         getAttribute: getAttribute,
@@ -38,6 +42,18 @@ void main() {
       );
       var out = env.fromString("{{ test_func() }}");
       expect(out.render(data), 'default42');
+    });
+  });
+  group('With Environment', ()
+  {
+    test('positional argument', () {
+      var data = {'bar': 42};
+      var env = Environment(
+        getAttribute: getAttribute,
+        globals: {'test_func': passEnvironment(testFuncWithEnvironment)},
+      );
+      var out = env.fromString("{{ test_func('positional argument value') }}");
+      expect(out.render(data), '[positional argument value] {default} env.commentStart = {#');
     });
   });
 }


### PR DESCRIPTION
In order to emulate macros I've added the ability to **passContext** to global functions.  I'm not sure if this is in line with your future intentions for macros but this ability will allow my team to replace our current Python Jinaja2 macros with what we already have with no changes to the templates.