### PR TITLE
give more info when an expression error occurs

### DIFF
--- a/lib/src/renderer.dart
+++ b/lib/src/renderer.dart
@@ -502,7 +502,7 @@ class StringSinkRenderer extends Visitor<StringSinkRenderContext, void> {
     var orElse = node.orElse;
 
     if (iterable == null) {
-      throw TypeError();
+      throw ArgumentError.notNull('${node.iterable}');
     }
 
     String render(Object? iterable, [int depth = 0]) {

--- a/test/statements/for_test.dart
+++ b/test/statements/for_test.dart
@@ -131,7 +131,7 @@ void main() {
 
     test('noniter', () {
       var tmpl = env.fromString('{% for item in none %}...{% endfor %}');
-      expect(() => tmpl.render(), throwsA(isA<TypeError>()));
+      expect(() => tmpl.render(), throwsA(isArgumentError));
     });
 
     test('recursive', () {


### PR DESCRIPTION
it is hard to understand what an error actually want to tell, so add more information when throwing a error.