### PR TITLE
add support for index-based arrays slicing

### DIFF
--- a/lib/src/compiler.dart
+++ b/lib/src/compiler.dart
@@ -455,4 +455,12 @@ class RuntimeCompiler implements Visitor<void, Node> {
       body: visitNode(node.body, context),
     );
   }
+
+  @override
+  Node visitSlice(Slice node, void context) {
+    return node.copyWith(
+      start: visitNode<Expression?>(node.start, context),
+      stop: visitNode<Expression?>(node.stop, context),
+    );
+  }
 }

--- a/lib/src/nodes.dart
+++ b/lib/src/nodes.dart
@@ -66,6 +66,49 @@ abstract base class Statement extends Node {
   const Statement();
 }
 
+final class Slice extends Expression {
+  const Slice({required this.value, required this.start, this.stop});
+
+  final Expression value;
+
+  final Expression? start;
+
+  final Expression? stop;
+
+  @override
+  R accept<C, R>(Visitor<C, R> visitor, C context) {
+    return visitor.visitSlice(this, context);
+  }
+
+  @override
+  Slice copyWith({Expression? start, Expression? stop}) {
+    return Slice(
+      value: value,
+      start: start ?? this.start,
+      stop: stop ?? this.stop,
+    );
+  }
+
+  @override
+  Iterable<T> findAll<T extends Node>() sync* {
+    if (value case T value) {
+      yield value;
+    }
+
+    yield* value.findAll<T>();
+  }
+
+  @override
+  Map<String, Object?> toJson() {
+    return <String, Object?>{
+      'class': 'Slice',
+      'start': start?.toJson(),
+      'stop': stop?.toJson(),
+      'value': value.toJson(),
+    };
+  }
+}
+
 final class Interpolation extends Node {
   const Interpolation({required this.value});
 

--- a/lib/src/optimizer.dart
+++ b/lib/src/optimizer.dart
@@ -424,4 +424,12 @@ class Optimizer implements Visitor<Context, Node> {
       body: visitNode<Node>(node.body, context),
     );
   }
+
+  @override
+  Node visitSlice(Slice node, Context context) {
+    return node.copyWith(
+      start: visitNode<Expression?>(node.start, context),
+      stop: visitNode<Expression?>(node.stop, context),
+    );
+  }
 }

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -1159,9 +1159,24 @@ final class Parser {
     }
 
     if (token.test('lbracket')) {
+      if (reader.nextIf('colon') != null) {
+        var stop = parseExpression(reader);
+        reader.expect('rbracket');
+        return Slice(start: null, stop: stop, value: value);
+      }
       var key = parseExpression(reader);
-      reader.expect('rbracket');
-      return Item(key: key, value: value);
+      if (reader.nextIf('colon') != null) {
+        if (reader.skipIf('rbracket')) {
+          return Slice(start: key, stop: null, value: value);
+        } else {
+          var stop = parseExpression(reader);
+          reader.expect('rbracket');
+          return Slice(start: key, stop: stop, value: value);
+        }
+      } else {
+        reader.expect('rbracket');
+        return Item(key: key, value: value);
+      }
     }
 
     fail('Expected subscript expression.', token.line);

--- a/lib/src/renderer.dart
+++ b/lib/src/renderer.dart
@@ -719,4 +719,17 @@ base class StringSinkRenderer
     var newContext = context.derived(data: data);
     node.body.accept(this, newContext);
   }
+
+  @override
+  Object? visitSlice(Slice node, StringSinkRenderContext context) {
+    var value = node.value.accept(this, context);
+    var start = node.start?.accept(this, context) ?? 0;
+    var stop = node.stop?.accept(this, context);
+
+    if (value is List && start is int && stop is int?) {
+      return value.sublist(start, stop);
+    }
+
+    throw TemplateRuntimeError('Invalid slice operation.');
+  }
 }

--- a/lib/src/visitor.dart
+++ b/lib/src/visitor.dart
@@ -78,6 +78,10 @@ abstract class Visitor<C, R> {
   R visitTemplateNode(TemplateNode node, C context);
 
   R visitWith(With node, C context);
+
+  R visitSlice(Slice node, C context) {
+    throw UnimplementedError();
+  }
 }
 
 class ThrowingVisitor<C, R> implements Visitor<C, R> {
@@ -264,6 +268,11 @@ class ThrowingVisitor<C, R> implements Visitor<C, R> {
 
   @override
   R visitWith(With node, C context) {
+    throw UnimplementedError();
+  }
+
+  @override
+  R visitSlice(Slice node, C context) {
     throw UnimplementedError();
   }
 }

--- a/test/slices_test.dart
+++ b/test/slices_test.dart
@@ -1,0 +1,25 @@
+import 'package:jinja/jinja.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Slices test', () {
+    test('sitems from the beginning through stop-1', () {
+      var environment = Environment();
+      var tmpl = environment
+          .fromString('{% set foo = [0, 1, 2, 3, 4] %}{{ foo[:2] }}');
+      expect(tmpl.render(), equals('[0, 1]'));
+    });
+    test('items start through the rest of the array', () {
+      var environment = Environment();
+      var tmpl = environment
+          .fromString('{% set foo = [0, 1, 2, 3, 4] %}{{ foo[2:] }}');
+      expect(tmpl.render(), equals('[2, 3, 4]'));
+    });
+    test('items start through stop-1', () {
+      var environment = Environment();
+      var tmpl = environment
+          .fromString('{% set foo = [0, 1, 2, 3, 4] %}{{ foo[2:3] }}');
+      expect(tmpl.render(), equals('[2]'));
+    });
+  });
+}


### PR DESCRIPTION
see #34 for more details. 

following syntax is supported:

`foo[:end]`
`foo[start:]`
`foo[start:end]`

   