### PR TITLE
Add regex_replace filter

### DIFF
--- a/lib/src/filters.dart
+++ b/lib/src/filters.dart
@@ -110,6 +110,57 @@ String doReplace(
   return value;
 }
 
+String _replaceRegexGroups(Match match, String replacement) {
+  return replacement.replaceAllMapped(RegExp(r'(\\|\$)(\d+)'), (ref) {
+    var index = int.parse(ref.group(2)!);
+    if (index > match.groupCount) {
+      return ref.group(0)!;
+    }
+
+    return match.group(index) ?? '';
+  });
+}
+
+/// Return a copy of the value with regular expression matches replaced.
+///
+/// If [count] is greater than zero, only the first `count` matches are
+/// replaced. Replacement references like `$1` and `\1` expand captured groups.
+String doRegexReplace(
+  String value,
+  String pattern,
+  String replacement, {
+  int count = 0,
+  bool ignoreCase = false,
+  bool multiLine = false,
+  bool dotAll = false,
+  bool unicode = false,
+}) {
+  var regex = RegExp(
+    pattern,
+    caseSensitive: !ignoreCase,
+    multiLine: multiLine,
+    dotAll: dotAll,
+    unicode: unicode,
+  );
+
+  if (count <= 0) {
+    return value.replaceAllMapped(
+      regex,
+      (match) => _replaceRegexGroups(match, replacement),
+    );
+  }
+
+  var replaced = 0;
+  return value.replaceAllMapped(regex, (match) {
+    if (replaced >= count) {
+      return match.group(0)!;
+    }
+
+    replaced += 1;
+    return _replaceRegexGroups(match, replacement);
+  });
+}
+
 /// Convert a value to uppercase.
 String doUpper(String value) {
   return value.toUpperCase();
@@ -632,6 +683,7 @@ final Map<String, Function> filters = <String, Function>{
   'string': doString,
   // 'urlencode': doURLEncode,
   'replace': doReplace,
+  'regex_replace': doRegexReplace,
   'upper': doUpper,
   'lower': doLower,
   'items': doItems,

--- a/test/filters_test.dart
+++ b/test/filters_test.dart
@@ -433,6 +433,19 @@ void main() {
       expect(tmpl.render({'string': '<foo>'}), equals('<f4242>'));
     });
 
+    test('regex_replace', () {
+      var tmpl = env.fromString(
+          r'{{ string|regex_replace("([A-Z]+)-([0-9]+)", "$2:$1") }}');
+      expect(tmpl.render({'string': 'REF-42'}), equals('42:REF'));
+
+      tmpl = env.fromString(r'{{ string|regex_replace(" +", "_", count=2) }}');
+      expect(tmpl.render({'string': 'a b c d'}), equals('a_b_c d'));
+
+      tmpl = env.fromString(
+          r'{{ string|regex_replace("^foo", "bar", ignoreCase=true, multiLine=true) }}');
+      expect(tmpl.render({'string': 'Foo\nbaz'}), equals('bar\nbaz'));
+    });
+
     test('forceescape', () {}, skip: 'Not supported.');
 
     test('safe', () {}, skip: 'Not supported.');


### PR DESCRIPTION
﻿## Summary
- add a built-in `regex_replace` filter for regular-expression replacement
- support optional `count`, `ignoreCase`, `multiLine`, `dotAll`, and `unicode` arguments
- expand `$1` and `\1` captured-group references in replacements

## Validation
- `dart test test\filters_test.dart`
- `dart test`

Closes #28.
