### PR TITLE
Add regex_replace filter

### DIFF
--- a/lib/src/filters.dart
+++ b/lib/src/filters.dart
@@ -110,6 +110,45 @@ String doReplace(
   return value;
 }
 
+/// Return a copy of the value with all matches of [pattern] replaced by
+/// [replacement].
+String doRegexReplace(
+  String value,
+  String pattern,
+  String replacement, {
+  int? count,
+  bool caseSensitive = true,
+  bool multiLine = false,
+  bool dotAll = false,
+  bool unicode = false,
+}) {
+  var regex = RegExp(
+    pattern,
+    caseSensitive: caseSensitive,
+    multiLine: multiLine,
+    dotAll: dotAll,
+    unicode: unicode,
+  );
+
+  if (count == null) {
+    return value.replaceAll(regex, replacement);
+  }
+
+  if (count <= 0) {
+    return value;
+  }
+
+  var replaced = 0;
+  return value.replaceAllMapped(regex, (match) {
+    if (replaced >= count) {
+      return match.group(0)!;
+    }
+
+    replaced += 1;
+    return replacement;
+  });
+}
+
 /// Convert a value to uppercase.
 String doUpper(String value) {
   return value.toUpperCase();
@@ -632,6 +671,7 @@ final Map<String, Function> filters = <String, Function>{
   'string': doString,
   // 'urlencode': doURLEncode,
   'replace': doReplace,
+  'regex_replace': doRegexReplace,
   'upper': doUpper,
   'lower': doLower,
   'items': doItems,

--- a/test/filters_test.dart
+++ b/test/filters_test.dart
@@ -433,6 +433,32 @@ void main() {
       expect(tmpl.render({'string': '<foo>'}), equals('<f4242>'));
     });
 
+    test('regex replace', () {
+      var tmpl = env.fromString(
+        '{{ string|regex_replace("[^A-Za-z0-9]+", "-") }}',
+      );
+      expect(
+        tmpl.render({'string': 'alpha, beta/gamma'}),
+        equals('alpha-beta-gamma'),
+      );
+
+      tmpl = env.fromString(
+        '{{ string|regex_replace("cat", "dog", caseSensitive=false) }}',
+      );
+      expect(
+        tmpl.render({'string': 'Cat cat catalog'}),
+        equals('dog dog dogalog'),
+      );
+
+      tmpl = env.fromString(r'{{ string|regex_replace("\d+", "#", count=2) }}');
+      expect(tmpl.render({'string': 'a1 b22 c333'}), equals('a# b# c333'));
+
+      tmpl = env.fromString(
+        '{{ string|regex_replace("^foo", "bar", multiLine=true) }}',
+      );
+      expect(tmpl.render({'string': 'foo\nfoo'}), equals('bar\nbar'));
+    });
+
     test('forceescape', () {}, skip: 'Not supported.');
 
     test('safe', () {}, skip: 'Not supported.');


### PR DESCRIPTION
## Summary
- adds a built-in `regex_replace` filter backed by Dart `RegExp`
- supports `count`, `caseSensitive`, `multiLine`, `dotAll`, and `unicode` options
- adds focused filter coverage for punctuation cleanup, case-insensitive matching, counted replacements, and multiline matching

## Validation
- `dart analyze`
- `dart test test\filters_test.dart`
- `dart test`